### PR TITLE
Add line to FMLControlledNamespacedRegistry#activateSubstitution  to

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -611,6 +611,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             I original = getRaw(nameToReplace);
             I sub = getPersistentSubstitutions().get(nameToReplace);
             getExistingDelegate(original).changeReference(sub);
+            getExistingDelegate(sub).setName(nameToReplace);
             activeSubstitutions.put(nameToReplace, sub);
             int id = getIDForObjectBypass(original);
             // force the new object into the existing map


### PR DESCRIPTION
change substitution name to name being replaced. Fixes #3131
